### PR TITLE
Players ranking

### DIFF
--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameServiceImpl.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameServiceImpl.java
@@ -13,6 +13,7 @@ import com.marafone.marafone.game.random.RandomAssigner;
 import com.marafone.marafone.game.model.*;
 import com.marafone.marafone.mappers.GameMapper;
 import com.marafone.marafone.user.User;
+import com.marafone.marafone.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -28,6 +29,7 @@ public class ActiveGameServiceImpl implements ActiveGameService{
 
     private final ActiveGameRepository activeGameRepository;
     private final EndedGameService endedGameService;
+    private final UserService userService;
     private final EventPublisher eventPublisher;
     private final List<Card> allCards;
     private final GameMapper gameMapper;
@@ -344,6 +346,12 @@ public class ActiveGameServiceImpl implements ActiveGameService{
                 winningAction.getPlayer().addBonusPoint();
 
                 if(game.setWinnersIfPossible()){
+                    userService.updateUsersStats(
+                            game.getGamePlayersFromTeam(Team.RED).stream().map(GamePlayer::getUser).toList(),
+                            game.getGamePlayersFromTeam(Team.BLUE).stream().map(GamePlayer::getUser).toList(),
+                            game.getWinnerTeam()
+                    );
+
                     outEvents.add(new PointState(game));
                     outEvents.add(new WinnerState(game));
 
@@ -489,5 +497,4 @@ public class ActiveGameServiceImpl implements ActiveGameService{
         redTeamTopScorer.subtractPoints(redTeamPoints % 3);
         blueTeamTopScorer.subtractPoints(blueTeamPoints % 3);
     }
-
 }

--- a/src/main/java/com/marafone/marafone/user/User.java
+++ b/src/main/java/com/marafone/marafone/user/User.java
@@ -29,6 +29,8 @@ public class User implements UserDetails {
     private Long id;
     private String username;
     private String email;
+    private int wins;
+    private int losses;
     @JsonIgnore
     private String password;
 
@@ -51,5 +53,11 @@ public class User implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+    public void increaseWins() {
+        wins++;
+    }
+    public void increaseLosses() {
+        losses++;
     }
 }

--- a/src/main/java/com/marafone/marafone/user/UserController.java
+++ b/src/main/java/com/marafone/marafone/user/UserController.java
@@ -1,28 +1,49 @@
 package com.marafone.marafone.user;
 
+import com.marafone.marafone.user.dto.RankingPageDTO;
+import com.marafone.marafone.user.dto.UserRankingDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @RestController
-@RequestMapping("/user")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
 
-    @GetMapping("/info")
+    @GetMapping("/user/info")
     public ResponseEntity<?> getUsername(Principal principal) {
         if (principal != null)
             return ResponseEntity.ok(Map.of("username", principal.getName()));
         else
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("User not authenticated.");
+    }
+
+    @GetMapping("/users/ranking")
+    public List<UserRankingDTO> getUsersRanking(Pageable pageable) {
+        return userService.getUsersRanking(pageable);
+    }
+
+    @GetMapping("/user/ranking")
+    public UserRankingDTO getUserRanking(Principal principal) {
+        return userService.getUserRanking(principal.getName());
+    }
+
+    @GetMapping("/users/{username}/ranking")
+    public ResponseEntity<RankingPageDTO> getRankingPageForUser(
+            @PathVariable("username") String username,
+            @RequestParam("pageSize") int pageSize
+    ) {
+        Optional<RankingPageDTO> rankingPageOptional = userService.getRankingPageForUser(username, pageSize);
+        return rankingPageOptional.map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
     }
 
 }

--- a/src/main/java/com/marafone/marafone/user/UserRepository.java
+++ b/src/main/java/com/marafone/marafone/user/UserRepository.java
@@ -1,10 +1,68 @@
 package com.marafone.marafone.user;
+import com.marafone.marafone.user.dto.UserRankingDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
+
+    @Query("""
+        SELECT new com.marafone.marafone.user.dto.UserRankingDTO(DENSE_RANK() OVER (
+            ORDER BY
+                CASE WHEN (u.wins + u.losses) = 0 THEN 0
+                ELSE (u.wins * 1.0 / (u.wins + u.losses)) END
+            DESC
+        ) AS position,
+        u.username,
+        u.wins,
+        u.losses)
+        FROM User u
+        """)
+    Page<UserRankingDTO> getTopUsers(Pageable pageable);
+
+    @Query("""
+        WITH RankedUsers AS (
+            SELECT
+                DENSE_RANK() OVER (
+                    ORDER BY
+                        CASE WHEN (u.wins + u.losses) = 0 THEN 0
+                        ELSE (u.wins * 1.0 / (u.wins + u.losses)) END
+                    DESC
+                ) AS position,
+                u.username AS username,
+                u.wins AS wins,
+                u.losses AS losses
+            FROM User u
+        )
+        SELECT new com.marafone.marafone.user.dto.UserRankingDTO(ru.position, ru.username, ru.wins, ru.losses)
+        FROM RankedUsers ru
+        WHERE ru.username = :username
+       """)
+    UserRankingDTO getTopUser(@Param("username") String username);
+
+    @Query("""
+        WITH RankedUsers AS (
+            SELECT
+                u.username AS username,
+                u.wins AS wins,
+                u.losses AS losses,
+                ROW_NUMBER() OVER (
+                    ORDER BY
+                        CASE WHEN (u.wins + u.losses) = 0 THEN 0
+                        ELSE (u.wins * 1.0 / (u.wins + u.losses)) END
+                    DESC
+                ) AS position
+            FROM User u
+        )
+        SELECT position FROM RankedUsers WHERE username = :username
+        """)
+    Optional<Integer> getUserRankingPosition(@Param("username") String username);
 }

--- a/src/main/java/com/marafone/marafone/user/UserRepository.java
+++ b/src/main/java/com/marafone/marafone/user/UserRepository.java
@@ -12,57 +12,53 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByUsername(String username);
-
-    @Query("""
-        SELECT new com.marafone.marafone.user.dto.UserRankingDTO(DENSE_RANK() OVER (
+    String ORDER_DESCENDING_BY_WIN_RATIO =
+            """
             ORDER BY
                 CASE WHEN (u.wins + u.losses) = 0 THEN 0
                 ELSE (u.wins * 1.0 / (u.wins + u.losses)) END
             DESC
-        ) AS position,
-        u.username,
-        u.wins,
-        u.losses)
-        FROM User u
-        """)
+            """;
+
+    Optional<User> findByUsername(String username);
+
+    @Query("SELECT new com.marafone.marafone.user.dto.UserRankingDTO(DENSE_RANK() OVER ("
+            + ORDER_DESCENDING_BY_WIN_RATIO + """
+            ) AS position,
+            u.username,
+            u.wins,
+            u.losses)
+            FROM User u
+            """)
     Page<UserRankingDTO> getTopUsers(Pageable pageable);
 
     @Query("""
-        WITH RankedUsers AS (
-            SELECT
-                DENSE_RANK() OVER (
-                    ORDER BY
-                        CASE WHEN (u.wins + u.losses) = 0 THEN 0
-                        ELSE (u.wins * 1.0 / (u.wins + u.losses)) END
-                    DESC
-                ) AS position,
-                u.username AS username,
-                u.wins AS wins,
-                u.losses AS losses
-            FROM User u
-        )
-        SELECT new com.marafone.marafone.user.dto.UserRankingDTO(ru.position, ru.username, ru.wins, ru.losses)
-        FROM RankedUsers ru
-        WHERE ru.username = :username
-       """)
+            WITH RankedUsers AS (
+                SELECT
+                    DENSE_RANK() OVER ("""
+                        + ORDER_DESCENDING_BY_WIN_RATIO + """
+                    ) AS position,
+                    u.username AS username,
+                    u.wins AS wins,
+                    u.losses AS losses
+                FROM User u
+            )
+            SELECT new com.marafone.marafone.user.dto.UserRankingDTO(ru.position, ru.username, ru.wins, ru.losses)
+            FROM RankedUsers ru
+            WHERE ru.username = :username
+            """)
     UserRankingDTO getTopUser(@Param("username") String username);
 
     @Query("""
-        WITH RankedUsers AS (
-            SELECT
-                u.username AS username,
-                u.wins AS wins,
-                u.losses AS losses,
-                ROW_NUMBER() OVER (
-                    ORDER BY
-                        CASE WHEN (u.wins + u.losses) = 0 THEN 0
-                        ELSE (u.wins * 1.0 / (u.wins + u.losses)) END
-                    DESC
-                ) AS position
-            FROM User u
-        )
-        SELECT position FROM RankedUsers WHERE username = :username
-        """)
+            WITH RankedUsers AS (
+                SELECT
+                    u.username AS username,
+                    ROW_NUMBER() OVER ("""
+                        + ORDER_DESCENDING_BY_WIN_RATIO + """
+                    ) AS position
+                FROM User u
+            )
+            SELECT position FROM RankedUsers WHERE username = :username
+            """)
     Optional<Integer> getUserRankingPosition(@Param("username") String username);
 }

--- a/src/main/java/com/marafone/marafone/user/UserService.java
+++ b/src/main/java/com/marafone/marafone/user/UserService.java
@@ -1,4 +1,16 @@
 package com.marafone.marafone.user;
 
+import com.marafone.marafone.game.model.Team;
+import com.marafone.marafone.user.dto.RankingPageDTO;
+import com.marafone.marafone.user.dto.UserRankingDTO;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
 public interface UserService {
+    List<UserRankingDTO> getUsersRanking(Pageable pageable);
+    UserRankingDTO getUserRanking(String username);
+    Optional<RankingPageDTO> getRankingPageForUser(String username, int pageSize);
+    void updateUsersStats(List<User> teamRed, List<User> teamBlue, Team winnerTeam);
 }

--- a/src/main/java/com/marafone/marafone/user/UserServiceImpl.java
+++ b/src/main/java/com/marafone/marafone/user/UserServiceImpl.java
@@ -1,7 +1,63 @@
 package com.marafone.marafone.user;
 
+import com.marafone.marafone.game.model.Team;
+import com.marafone.marafone.user.dto.RankingPageDTO;
+import com.marafone.marafone.user.dto.UserRankingDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
 @Service
+@RequiredArgsConstructor
 public class UserServiceImpl implements UserService{
+
+    private final UserRepository userRepository;
+
+    @Override
+    public List<UserRankingDTO> getUsersRanking(Pageable pageable) {
+        return userRepository.getTopUsers(pageable).getContent();
+    }
+
+    @Override
+    public UserRankingDTO getUserRanking(String username) {
+        return userRepository.getTopUser(username);
+    }
+
+    @Override
+    public Optional<RankingPageDTO> getRankingPageForUser(String username, int pageSize) {
+        Optional<Integer> userRankingPositionOptional = userRepository.getUserRankingPosition(username);
+
+        if (userRankingPositionOptional.isEmpty())
+            return Optional.empty();
+
+        Integer userRankingPosition = userRankingPositionOptional.get();
+
+        int pageNumber = calculatePageNumber(userRankingPosition, pageSize);
+        List<UserRankingDTO> userRankingDTOS = getUsersRanking(PageRequest.of(pageNumber, pageSize));
+
+        return Optional.of(new RankingPageDTO(userRankingDTOS, pageNumber));
+    }
+
+    public void updateUsersStats(List<User> teamRed, List<User> teamBlue, Team winnerTeam) {
+        List<User> winningTeam = (winnerTeam == Team.RED) ? teamRed : teamBlue;
+        List<User> losingTeam = (winnerTeam == Team.RED) ? teamBlue : teamRed;
+
+        for (var user: winningTeam)
+            user.increaseWins();
+
+        for (var user: losingTeam)
+            user.increaseLosses();
+
+        userRepository.saveAll(winningTeam);
+        userRepository.saveAll(losingTeam);
+    }
+
+    private int calculatePageNumber(int position, int pageSize) {
+        return ((position - 1) / pageSize);
+    }
 }

--- a/src/main/java/com/marafone/marafone/user/UserServiceImpl.java
+++ b/src/main/java/com/marafone/marafone/user/UserServiceImpl.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.List;
@@ -43,6 +44,7 @@ public class UserServiceImpl implements UserService{
         return Optional.of(new RankingPageDTO(userRankingDTOS, pageNumber));
     }
 
+    @Transactional
     public void updateUsersStats(List<User> teamRed, List<User> teamBlue, Team winnerTeam) {
         List<User> winningTeam = (winnerTeam == Team.RED) ? teamRed : teamBlue;
         List<User> losingTeam = (winnerTeam == Team.RED) ? teamBlue : teamRed;
@@ -52,9 +54,6 @@ public class UserServiceImpl implements UserService{
 
         for (var user: losingTeam)
             user.increaseLosses();
-
-        userRepository.saveAll(winningTeam);
-        userRepository.saveAll(losingTeam);
     }
 
     private int calculatePageNumber(int position, int pageSize) {

--- a/src/main/java/com/marafone/marafone/user/dto/RankingPageDTO.java
+++ b/src/main/java/com/marafone/marafone/user/dto/RankingPageDTO.java
@@ -1,0 +1,6 @@
+package com.marafone.marafone.user.dto;
+
+import java.util.List;
+
+public record RankingPageDTO(List<UserRankingDTO> users, int pageNumber) {
+}

--- a/src/main/java/com/marafone/marafone/user/dto/UserRankingDTO.java
+++ b/src/main/java/com/marafone/marafone/user/dto/UserRankingDTO.java
@@ -1,0 +1,4 @@
+package com.marafone.marafone.user.dto;
+
+public record UserRankingDTO(Long position, String username, int wins, int losses) {
+}

--- a/src/test/java/com/marafone/marafone/game/active/ActiveGameServiceImplTest.java
+++ b/src/test/java/com/marafone/marafone/game/active/ActiveGameServiceImplTest.java
@@ -9,6 +9,8 @@ import com.marafone.marafone.game.model.*;
 import com.marafone.marafone.game.random.MarafoneRandomAssigner;
 import com.marafone.marafone.mappers.GameMapper;
 import com.marafone.marafone.user.User;
+import com.marafone.marafone.user.UserRepository;
+import com.marafone.marafone.user.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +34,8 @@ class ActiveGameServiceImplTest {
     @Mock
     private ActiveGameRepository activeGameRepository;
     @Mock
+    private UserService userService;
+    @Mock
     private EndedGameService endedGameService;
     @Mock
     private EventPublisher eventPublisher;
@@ -42,7 +46,7 @@ class ActiveGameServiceImplTest {
 
     @BeforeEach
     void setUp(){
-        activeGameServiceImpl = new ActiveGameServiceImpl(activeGameRepository, endedGameService, eventPublisher,
+        activeGameServiceImpl = new ActiveGameServiceImpl(activeGameRepository, endedGameService, userService, eventPublisher,
                 new GameConfig().allCards(), gameMapper, new MarafoneRandomAssigner(new GameConfig().allCards(), new GameConfig().random()));
     }
 
@@ -268,10 +272,10 @@ class ActiveGameServiceImplTest {
     @Test
     void leaveGame_WhenUserInGame_ShouldRemoveUserFromGamePlayersList() {
         // given
-        User user = new User(1L, "user1", "", "user1");
+        User user = new User(1L, "user1", "", 0, 0, "user1");
         GamePlayer gp1 = GamePlayer
                 .builder()
-                .user(new User(2L, "user2", "", "user2"))
+                .user(new User(2L, "user2", "", 0, 0, "user2"))
                 .build();
         GamePlayer gp2 = GamePlayer
                 .builder()
@@ -279,7 +283,7 @@ class ActiveGameServiceImplTest {
                 .build();
         GamePlayer gp3 = GamePlayer
                 .builder()
-                .user(new User(3L, "user3", "", "user3"))
+                .user(new User(3L, "user3", "", 0, 0, "user3"))
                 .build();
 
         List<GamePlayer> playersList = new ArrayList<>();
@@ -301,14 +305,14 @@ class ActiveGameServiceImplTest {
     @Test
     void leaveGame_WhenUserNotInGame_ShouldDoNothing() {
         // given
-        User user = new User(1L, "user1", "", "user1");
+        User user = new User(1L, "user1", "", 0, 0, "user1");
         GamePlayer gp1 = GamePlayer
                 .builder()
-                .user(new User(2L, "user2", "", "user2"))
+                .user(new User(2L, "user2", "", 0, 0, "user2"))
                 .build();
         GamePlayer gp2 = GamePlayer
                 .builder()
-                .user(new User(3L, "user3", "", "user3"))
+                .user(new User(3L, "user3", "", 0, 0, "user3"))
                 .build();
 
         List<GamePlayer> playersList = new ArrayList<>();
@@ -329,9 +333,9 @@ class ActiveGameServiceImplTest {
     void changeTeam_WhenTeamNotFull_ShouldChangeTeams() {
         // given
         List<User> users = Arrays.asList(
-                new User(1L, "user1", "", "user1"),
-                new User(2L, "user2", "", "user2"),
-                new User(3L, "user3", "", "user3")
+                new User(1L, "user1", "", 0, 0, "user1"),
+                new User(2L, "user2", "", 0, 0, "user2"),
+                new User(3L, "user3", "", 0, 0, "user3")
         );
         List<GamePlayer> gamePlayersList = Arrays.asList(
             new GamePlayer(1L, users.get(0), Team.RED, null, null),
@@ -355,10 +359,10 @@ class ActiveGameServiceImplTest {
     void changeTeam_WhenTeamFull_ShouldNotAllowUserToChangeTeam() {
         // given
         List<User> users = Arrays.asList(
-                new User(1L, "user1", "", "user1"),
-                new User(2L, "user2", "", "user2"),
-                new User(3L, "user3", "", "user3"),
-                new User(4L, "user4", "", "user4")
+                User.builder().id(1L).username("user1").build(),
+                User.builder().id(2L).username("user2").build(),
+                User.builder().id(3L).username("user3").build(),
+                User.builder().id(4L).username("user4").build()
         );
         List<GamePlayer> gamePlayersList = Arrays.asList(
                 new GamePlayer(1L, users.get(0), Team.RED, null, null),
@@ -381,8 +385,8 @@ class ActiveGameServiceImplTest {
     void changeTeam_WhenTargetTeamIsSameAsCurrentTeam_ShouldNotChangeTeams() {
         // given
         List<User> users = Arrays.asList(
-                new User(1L, "user1", "", "user1"),
-                new User(2L, "user2", "", "user2")
+                User.builder().id(1L).username("user1").build(),
+                User.builder().id(2L).username("user2").build()
         );
         List<GamePlayer> gamePlayersList = Arrays.asList(
                 new GamePlayer(1L, users.get(0), Team.RED, null, null),
@@ -430,10 +434,10 @@ class ActiveGameServiceImplTest {
     @Test
     void changeTeam_WhenUserNotInGame_ShouldDoNothing() {
         // given
-        User user = new User(1L, "user1", "", "user1");
+        User user = User.builder().id(1L).username("user1").build();
         Game game = Game.builder()
                 .playersList(new LinkedList<>(List.of(
-                        new GamePlayer(2L, new User(2L, "user2", "", "user2"), Team.RED, null, null)
+                        new GamePlayer(2L, User.builder().id(2L).username("user2").build(), Team.RED, null, null)
                 )))
                 .id(1L)
                 .build();


### PR DESCRIPTION
Users now store their wins and losses, allowing them to be ranked based on their win ratio. 
I added three API endpoints to handle player rankings:

1) Retrieve the ranking of players on a specific page.
2) Fetch the ranking position of the current user.
3) Search for a player by name and return their ranking position (it is done by returning entire ranking page on which user is present).
Additionally, user stats are now updated after a game win/loss. ActiveGameService now relies on UserService for these updates.

New DTOs were introduced:
1) UserRankingDTO for ranking data.
2) RankingPageDTO that also includes the page number where the searched player was found, enabling the frontend to update the page correctly.