### PR TITLE
Improve Error Handling and Game Joining/Reconnection Logic.

### DIFF
--- a/src/main/java/com/marafone/marafone/errors/CreateGameErrorMessages.java
+++ b/src/main/java/com/marafone/marafone/errors/CreateGameErrorMessages.java
@@ -1,0 +1,14 @@
+package com.marafone.marafone.errors;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CreateGameErrorMessages {
+    GAME_NAME_TAKEN("Game name already taken. Try with the other name."),
+    PLAYER_LEFT_ANOTHER_GAME("You are already a member of another game that you left. " +
+            "Either rejoin the game you left or wait until that game ends.");
+
+    private final String message;
+}

--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameController.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameController.java
@@ -39,7 +39,7 @@ public class ActiveGameController {
 
     @GetMapping("/game/active")
     @ResponseBody
-    public ResponseEntity<Long> getUserActiveGame(Principal principal) {
+    public ResponseEntity<Long> getUserActiveGameId(Principal principal) {
         var optionalGameId = activeGameService.getActiveGameForPlayer(principal.getName());
         return optionalGameId
                 .map(ResponseEntity::ok)

--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameController.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameController.java
@@ -37,10 +37,10 @@ public class ActiveGameController {
         return activeGameService.getWaitingGames();
     }
 
-    @GetMapping("/game/reconnectable")
+    @GetMapping("/game/active")
     @ResponseBody
-    public ResponseEntity<Long> getReconnectableGame(Principal principal) {
-        var optionalGameId = activeGameService.getReconnectableGameForPlayer(principal.getName());
+    public ResponseEntity<Long> getUserActiveGame(Principal principal) {
+        var optionalGameId = activeGameService.getActiveGameForPlayer(principal.getName());
         return optionalGameId
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.noContent().build());
@@ -51,7 +51,7 @@ public class ActiveGameController {
     public synchronized ResponseEntity<String> createGame(@RequestBody CreateGameRequest createGameRequest, @AuthenticationPrincipal User user){
         if (activeGameService.doesNotStartedGameAlreadyExist(createGameRequest.getGameName()))
             return ResponseEntity.badRequest().body(CreateGameErrorMessages.GAME_NAME_TAKEN.getMessage());
-        else if (activeGameService.getReconnectableGameForPlayer(user.getUsername()).isPresent())
+        else if (user.isInGame())
             return ResponseEntity.badRequest().body(CreateGameErrorMessages.PLAYER_LEFT_ANOTHER_GAME.getMessage());
 
         Long gameId = activeGameService.createGame(createGameRequest, user);

--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameController.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameController.java
@@ -49,6 +49,8 @@ public class ActiveGameController {
     @PostMapping("/game/create")
     @ResponseBody
     public synchronized ResponseEntity<String> createGame(@RequestBody CreateGameRequest createGameRequest, @AuthenticationPrincipal User user){
+        activeGameService.syncUserGameStatus(user);
+
         if (activeGameService.doesNotStartedGameAlreadyExist(createGameRequest.getGameName()))
             return ResponseEntity.badRequest().body(CreateGameErrorMessages.GAME_NAME_TAKEN.getMessage());
         else if (user.isInGame())

--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameController.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameController.java
@@ -49,11 +49,10 @@ public class ActiveGameController {
     @PostMapping("/game/create")
     @ResponseBody
     public synchronized ResponseEntity<String> createGame(@RequestBody CreateGameRequest createGameRequest, @AuthenticationPrincipal User user){
-        activeGameService.syncUserGameStatus(user);
 
         if (activeGameService.doesNotStartedGameAlreadyExist(createGameRequest.getGameName()))
             return ResponseEntity.badRequest().body(CreateGameErrorMessages.GAME_NAME_TAKEN.getMessage());
-        else if (user.isInGame())
+        else if (user.isInGame(activeGameService::checkIfUserIsInGame))
             return ResponseEntity.badRequest().body(CreateGameErrorMessages.PLAYER_LEFT_ANOTHER_GAME.getMessage());
 
         Long gameId = activeGameService.createGame(createGameRequest, user);

--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameRepository.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameRepository.java
@@ -10,4 +10,5 @@ public interface ActiveGameRepository {
     void removeById(Long id);
     Long put(Game game);
     List<Game> getWaitingGames();
+    List<Game> getStartedGames();
 }

--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameRepositoryImpl.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameRepositoryImpl.java
@@ -47,4 +47,12 @@ public class ActiveGameRepositoryImpl implements ActiveGameRepository{
                 .filter(game -> !game.hasStarted() && game.isPublic() && game.anyTeamNotFull())
                 .toList();
     }
+
+    @Override
+    public List<Game> getStartedGames() {
+        return activeGames.values()
+                .stream()
+                .filter(Game::hasStarted)
+                .toList();
+    }
 }

--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameRepositoryImplCache.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameRepositoryImplCache.java
@@ -41,4 +41,9 @@ public class ActiveGameRepositoryImplCache implements ActiveGameRepository{
 
         return LastSnapshotData;
     }
+
+    @Override
+    public List<Game> getStartedGames() {
+        return activeGameRepositoryImpl.getStartedGames();
+    }
 }

--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameService.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameService.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 
 public interface ActiveGameService {
     List<GameDTO> getWaitingGames();
-    Optional<Long> getReconnectableGameForPlayer(String playerName);
+    Optional<Long> getActiveGameForPlayer(String playerName);
     Long createGame(CreateGameRequest createGameRequest, User user);
     JoinGameResult joinGame(Long gameId, JoinGameRequest joinGameRequest, User user);
     void leaveGame(Long gameId, User user);

--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameService.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameService.java
@@ -12,9 +12,11 @@ import com.marafone.marafone.user.User;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ActiveGameService {
     List<GameDTO> getWaitingGames();
+    Optional<Long> getReconnectableGameForPlayer(String playerName);
     Long createGame(CreateGameRequest createGameRequest, User user);
     JoinGameResult joinGame(Long gameId, JoinGameRequest joinGameRequest, User user);
     void leaveGame(Long gameId, User user);

--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameService.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameService.java
@@ -28,4 +28,5 @@ public interface ActiveGameService {
     void sendCall(Long gameId, Call call);
     void reconnectToGame(Long gameId, String principalName);
     boolean doesNotStartedGameAlreadyExist(String name);
+    void syncUserGameStatus(User user);
 }

--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameService.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameService.java
@@ -28,5 +28,5 @@ public interface ActiveGameService {
     void sendCall(Long gameId, Call call);
     void reconnectToGame(Long gameId, String principalName);
     boolean doesNotStartedGameAlreadyExist(String name);
-    void syncUserGameStatus(User user);
+    boolean checkIfUserIsInGame(User user);
 }

--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameServiceImpl.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameServiceImpl.java
@@ -82,20 +82,17 @@ public class ActiveGameServiceImpl implements ActiveGameService{
     }
 
     @Override
-    public void syncUserGameStatus(User user) {
-        if (user.isInGame() && getActiveGameForPlayer(user.getUsername()).isEmpty())
-            user.setInGame(false);
+    public boolean checkIfUserIsInGame(User user) {
+        return getActiveGameForPlayer(user.getUsername()).isPresent();
     }
 
     @Override
     public JoinGameResult joinGame(Long gameId, JoinGameRequest joinGameRequest, User user) {
         Optional<Game> gameOptional = activeGameRepository.findById(gameId);
 
-        syncUserGameStatus(user);
-
         if (gameOptional.isEmpty())
             return JoinGameResult.GAME_NOT_FOUND;
-        else if (user.isInGame())
+        else if (user.isInGame(this::checkIfUserIsInGame))
             return JoinGameResult.PLAYER_DURING_ANOTHER_GAME;
 
         Game game = gameOptional.get();

--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameServiceImpl.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameServiceImpl.java
@@ -44,6 +44,17 @@ public class ActiveGameServiceImpl implements ActiveGameService{
                         .toList();
     }
 
+    public Optional<Long> getReconnectableGameForPlayer(String playerName) {
+        List<Game> startedGames = activeGameRepository.getStartedGames();
+        return startedGames.stream()
+                           .filter(game -> game.getPlayersList()
+                                     .stream()
+                                     .map(gp -> gp.getUser().getUsername())
+                                     .anyMatch(username -> username.equals(playerName)))
+                           .map(Game::getId)
+                           .findFirst();
+    }
+
     @Override
     public Long createGame(CreateGameRequest createGameRequest, User user) {
         GamePlayer gamePlayer = createGamePlayer(user, Team.RED);
@@ -76,6 +87,8 @@ public class ActiveGameServiceImpl implements ActiveGameService{
 
         if(gameOptional.isEmpty())
             return JoinGameResult.GAME_NOT_FOUND;
+        else if (getReconnectableGameForPlayer(user.getUsername()).isPresent())
+            return JoinGameResult.PLAYER_DURING_ANOTHER_GAME;
 
         Game game = gameOptional.get();
 

--- a/src/main/java/com/marafone/marafone/game/model/JoinGameResult.java
+++ b/src/main/java/com/marafone/marafone/game/model/JoinGameResult.java
@@ -11,7 +11,8 @@ public enum JoinGameResult {
     TEAMS_FULL("Game team is already full"),
     GAME_ALREADY_STARTED("The game has already started"),
     INCORRECT_PASSWORD("Provided password was incorrect"),
-    PLAYER_ALREADY_JOINED("You have already joined this game");
+    PLAYER_ALREADY_JOINED("You have already joined this game"),
+    PLAYER_DURING_ANOTHER_GAME("You are already a member of another game");
 
     private final String message;
 }

--- a/src/main/java/com/marafone/marafone/user/User.java
+++ b/src/main/java/com/marafone/marafone/user/User.java
@@ -31,6 +31,7 @@ public class User implements UserDetails {
     private String email;
     private int wins;
     private int losses;
+    private boolean isInGame;
     @JsonIgnore
     private String password;
 

--- a/src/main/java/com/marafone/marafone/user/User.java
+++ b/src/main/java/com/marafone/marafone/user/User.java
@@ -16,6 +16,9 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 @Entity
 @Data
@@ -60,5 +63,21 @@ public class User implements UserDetails {
     }
     public void increaseLosses() {
         losses++;
+    }
+
+    /*
+        isInGame value cannot be trusted when set to true, as server can crash during game
+         and game end without isInGame value being set back to false, thus this method accepts
+          more time-consuming function that checks all active games
+     */
+    public boolean isInGame(Function<User,Boolean> checkUserInAllGames){
+        if(!isInGame)
+            return false;
+
+        if(!checkUserInAllGames.apply(this)){
+            isInGame = false;
+        }
+
+        return isInGame;
     }
 }

--- a/src/test/java/com/marafone/marafone/game/active/ActiveGameControllerTest.java
+++ b/src/test/java/com/marafone/marafone/game/active/ActiveGameControllerTest.java
@@ -4,14 +4,23 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marafone.marafone.game.ended.EndedGameService;
 import com.marafone.marafone.game.event.incoming.CreateGameRequest;
 import com.marafone.marafone.game.model.GameType;
+import com.marafone.marafone.user.User;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -50,13 +59,45 @@ class ActiveGameControllerTest {
     }
 
     @Test
-    @WithMockUser(username = "testUser" )
-    void createGame_WhenGameDoesNotExist_ShouldReturnOkResponseInfo() throws Exception {
+    void createGame_WhenUserInAnotherGame_ShouldReturnBadRequestInfo() throws Exception {
         // given
+        User mockedUser = Mockito.mock(User.class);
+        Mockito.when(mockedUser.getUsername()).thenReturn("testUser");
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = new UsernamePasswordAuthenticationToken(mockedUser, null, List.of());
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+
         CreateGameRequest createGameRequest =
                 new CreateGameRequest("game", GameType.MARAFFA, "", 21);
 
         Mockito.when(activeGameService.doesNotStartedGameAlreadyExist(Mockito.any())).thenReturn(false);
+        Mockito.when(activeGameService.getReconnectableGameForPlayer(Mockito.any())).thenReturn(Optional.of(1L));
+        String jsonRequest = new ObjectMapper().writeValueAsString(createGameRequest);
+
+        // when & then
+        mockMvc.perform(post("/game/create")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonRequest)
+                .with(csrf())) // to include csrf token for authentication
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createGame_WhenGameDoesNotExist_ShouldReturnOkResponseInfo() throws Exception {
+        // given
+        User mockedUser = Mockito.mock(User.class);
+        Mockito.when(mockedUser.getUsername()).thenReturn("testUser");
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = new UsernamePasswordAuthenticationToken(mockedUser, null, List.of());
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+
+        CreateGameRequest createGameRequest =
+                new CreateGameRequest("game", GameType.MARAFFA, "", 21);
+
+        Mockito.when(activeGameService.doesNotStartedGameAlreadyExist(Mockito.any())).thenReturn(false);
+        Mockito.when(activeGameService.getReconnectableGameForPlayer(Mockito.any())).thenReturn(Optional.empty());
         String jsonRequest = new ObjectMapper().writeValueAsString(createGameRequest);
 
         // when & then

--- a/src/test/java/com/marafone/marafone/game/active/ActiveGameControllerTest.java
+++ b/src/test/java/com/marafone/marafone/game/active/ActiveGameControllerTest.java
@@ -16,7 +16,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -72,7 +71,7 @@ class ActiveGameControllerTest {
                 new CreateGameRequest("game", GameType.MARAFFA, "", 21);
 
         Mockito.when(activeGameService.doesNotStartedGameAlreadyExist(Mockito.any())).thenReturn(false);
-        Mockito.when(activeGameService.getReconnectableGameForPlayer(Mockito.any())).thenReturn(Optional.of(1L));
+        Mockito.when(mockedUser.isInGame()).thenReturn(true);
         String jsonRequest = new ObjectMapper().writeValueAsString(createGameRequest);
 
         // when & then
@@ -97,7 +96,7 @@ class ActiveGameControllerTest {
                 new CreateGameRequest("game", GameType.MARAFFA, "", 21);
 
         Mockito.when(activeGameService.doesNotStartedGameAlreadyExist(Mockito.any())).thenReturn(false);
-        Mockito.when(activeGameService.getReconnectableGameForPlayer(Mockito.any())).thenReturn(Optional.empty());
+        Mockito.when(activeGameService.getActiveGameForPlayer(Mockito.any())).thenReturn(Optional.empty());
         String jsonRequest = new ObjectMapper().writeValueAsString(createGameRequest);
 
         // when & then

--- a/src/test/java/com/marafone/marafone/game/active/ActiveGameControllerTest.java
+++ b/src/test/java/com/marafone/marafone/game/active/ActiveGameControllerTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -46,7 +47,7 @@ class ActiveGameControllerTest {
         CreateGameRequest createGameRequest =
                 new CreateGameRequest("game", GameType.MARAFFA, "", 21);
 
-        Mockito.when(activeGameService.doesNotStartedGameAlreadyExist(Mockito.any())).thenReturn(true);
+        Mockito.when(activeGameService.doesNotStartedGameAlreadyExist(any())).thenReturn(true);
         String jsonRequest = new ObjectMapper().writeValueAsString(createGameRequest);
 
         // when & then
@@ -70,8 +71,8 @@ class ActiveGameControllerTest {
         CreateGameRequest createGameRequest =
                 new CreateGameRequest("game", GameType.MARAFFA, "", 21);
 
-        Mockito.when(activeGameService.doesNotStartedGameAlreadyExist(Mockito.any())).thenReturn(false);
-        Mockito.when(mockedUser.isInGame()).thenReturn(true);
+        Mockito.when(activeGameService.doesNotStartedGameAlreadyExist(any())).thenReturn(false);
+        Mockito.when(mockedUser.isInGame(any())).thenReturn(true);
         String jsonRequest = new ObjectMapper().writeValueAsString(createGameRequest);
 
         // when & then
@@ -95,8 +96,8 @@ class ActiveGameControllerTest {
         CreateGameRequest createGameRequest =
                 new CreateGameRequest("game", GameType.MARAFFA, "", 21);
 
-        Mockito.when(activeGameService.doesNotStartedGameAlreadyExist(Mockito.any())).thenReturn(false);
-        Mockito.when(activeGameService.getActiveGameForPlayer(Mockito.any())).thenReturn(Optional.empty());
+        Mockito.when(activeGameService.doesNotStartedGameAlreadyExist(any())).thenReturn(false);
+        Mockito.when(activeGameService.getActiveGameForPlayer(any())).thenReturn(Optional.empty());
         String jsonRequest = new ObjectMapper().writeValueAsString(createGameRequest);
 
         // when & then

--- a/src/test/java/com/marafone/marafone/game/active/ActiveGameServiceImplIntegrationWithMocksTest.java
+++ b/src/test/java/com/marafone/marafone/game/active/ActiveGameServiceImplIntegrationWithMocksTest.java
@@ -254,6 +254,9 @@ public class ActiveGameServiceImplIntegrationWithMocksTest {
         //ENEMY TEAM SHOULD WIN
         assertEquals(1, game.getRounds().size());
         assertEquals(Team.BLUE, game.getWinnerTeam());
+
+        // REMOVE CREATED GAME
+        activeGameRepository.removeById(gameId);
     }
 
     @Test
@@ -578,6 +581,9 @@ public class ActiveGameServiceImplIntegrationWithMocksTest {
         //OWNER TEAM SHOULD WIN
         assertEquals(2, game.getRounds().size());
         assertEquals(Team.RED, game.getWinnerTeam());
+
+        // REMOVE CREATED GAME
+        activeGameRepository.removeById(gameId);
     }
 
 }

--- a/src/test/java/com/marafone/marafone/game/active/ActiveGameServiceImplTest.java
+++ b/src/test/java/com/marafone/marafone/game/active/ActiveGameServiceImplTest.java
@@ -272,10 +272,10 @@ class ActiveGameServiceImplTest {
     @Test
     void leaveGame_WhenUserInGame_ShouldRemoveUserFromGamePlayersList() {
         // given
-        User user = new User(1L, "user1", "", 0, 0, "user1");
+        User user = User.builder().id(1L).username("user1").build();
         GamePlayer gp1 = GamePlayer
                 .builder()
-                .user(new User(2L, "user2", "", 0, 0, "user2"))
+                .user(User.builder().id(2L).username("user2").build())
                 .build();
         GamePlayer gp2 = GamePlayer
                 .builder()
@@ -283,7 +283,7 @@ class ActiveGameServiceImplTest {
                 .build();
         GamePlayer gp3 = GamePlayer
                 .builder()
-                .user(new User(3L, "user3", "", 0, 0, "user3"))
+                .user(User.builder().id(3L).username("user3").build())
                 .build();
 
         List<GamePlayer> playersList = new ArrayList<>();
@@ -305,14 +305,14 @@ class ActiveGameServiceImplTest {
     @Test
     void leaveGame_WhenUserNotInGame_ShouldDoNothing() {
         // given
-        User user = new User(1L, "user1", "", 0, 0, "user1");
+        User user = User.builder().id(1L).username("user1").build();
         GamePlayer gp1 = GamePlayer
                 .builder()
-                .user(new User(2L, "user2", "", 0, 0, "user2"))
+                .user(User.builder().id(2L).username("user2").build())
                 .build();
         GamePlayer gp2 = GamePlayer
                 .builder()
-                .user(new User(3L, "user3", "", 0, 0, "user3"))
+                .user(User.builder().id(3L).username("user3").build())
                 .build();
 
         List<GamePlayer> playersList = new ArrayList<>();
@@ -333,9 +333,9 @@ class ActiveGameServiceImplTest {
     void changeTeam_WhenTeamNotFull_ShouldChangeTeams() {
         // given
         List<User> users = Arrays.asList(
-                new User(1L, "user1", "", 0, 0, "user1"),
-                new User(2L, "user2", "", 0, 0, "user2"),
-                new User(3L, "user3", "", 0, 0, "user3")
+                User.builder().id(1L).username("user1").build(),
+                User.builder().id(2L).username("user2").build(),
+                User.builder().id(3L).username("user3").build()
         );
         List<GamePlayer> gamePlayersList = Arrays.asList(
             new GamePlayer(1L, users.get(0), Team.RED, null, null),


### PR DESCRIPTION
Error Handling Enums:
Created enums to simplify error handling for create game requests.
Added a specific error for the case where a user, who has left a previous game, attempts to create a new game before the previous one has ended.

Reconnectable Game Endpoint:
Introduced an endpoint to retrieve a reconnectable game. This is useful for checking if a user can return to a game they left (whether intentionally or due to connectivity issues). 

Join Game Method Update:
Updated the join method to prevent a user from joining a new game while still being part of a previous one.