### PR TITLE
Private games

### DIFF
--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameRepositoryImpl.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.marafone.marafone.game.active;
 
 import com.marafone.marafone.game.model.Game;
-import com.marafone.marafone.game.model.Team;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -44,7 +43,7 @@ public class ActiveGameRepositoryImpl implements ActiveGameRepository{
     @Override
     public List<Game> getWaitingGames() {
         return activeGames.values().stream()
-                .filter(game -> !game.hasStarted() && game.isPublic() && game.anyTeamNotFull())
+                .filter(game -> !game.hasStarted() && game.anyTeamNotFull())
                 .toList();
     }
 

--- a/src/main/java/com/marafone/marafone/game/active/ActiveGameServiceImpl.java
+++ b/src/main/java/com/marafone/marafone/game/active/ActiveGameServiceImpl.java
@@ -107,7 +107,7 @@ public class ActiveGameServiceImpl implements ActiveGameService{
                 return TEAMS_FULL;
             else if (game.hasStarted())
                 return GAME_ALREADY_STARTED;
-            else if (!game.checkCode(joinGameRequest.joinGameCode))
+            else if (!game.checkCode(joinGameRequest.joinGameCode()))
                 return INCORRECT_PASSWORD;
             else if (game.playerAlreadyJoined(user.getUsername()))
                 return PLAYER_ALREADY_JOINED;

--- a/src/main/java/com/marafone/marafone/game/dto/GameDTO.java
+++ b/src/main/java/com/marafone/marafone/game/dto/GameDTO.java
@@ -2,5 +2,5 @@ package com.marafone.marafone.game.dto;
 
 import com.marafone.marafone.game.model.GameType;
 
-public record GameDTO(String gameId, String gameName, GameType gameType, Integer joinedPlayersAmount) {
+public record GameDTO(String gameId, String gameName, GameType gameType, Integer joinedPlayersAmount, boolean isPrivate) {
 }

--- a/src/main/java/com/marafone/marafone/game/event/incoming/JoinGameRequest.java
+++ b/src/main/java/com/marafone/marafone/game/event/incoming/JoinGameRequest.java
@@ -1,10 +1,4 @@
 package com.marafone.marafone.game.event.incoming;
 
-import com.marafone.marafone.game.model.Team;
-import lombok.AllArgsConstructor;
-
-@AllArgsConstructor
-public class JoinGameRequest {
-    public Team team;
-    public String joinGameCode;
+public record JoinGameRequest(String joinGameCode) {
 }

--- a/src/main/java/com/marafone/marafone/mappers/GameMapper.java
+++ b/src/main/java/com/marafone/marafone/mappers/GameMapper.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class GameMapper {
     public GameDTO toGameDTO(Game game) {
-        return new GameDTO(String.valueOf(game.getId()), game.getName(), game.getGameType(), game.getPlayersAmount());
+        boolean isPrivate = game.getJoinGameCode() != null && !game.getJoinGameCode().isEmpty();
+        return new GameDTO(String.valueOf(game.getId()), game.getName(), game.getGameType(), game.getPlayersAmount(), isPrivate);
     }
 }

--- a/src/test/java/com/marafone/marafone/DummyData.java
+++ b/src/test/java/com/marafone/marafone/DummyData.java
@@ -167,7 +167,7 @@ public class DummyData {
     }
 
     public static JoinGameRequest getJoinGameRequestA(){
-        return new JoinGameRequest(Team.BLUE, null);
+        return new JoinGameRequest(null);
     }
 
 }

--- a/src/test/java/com/marafone/marafone/game/active/ActiveGameServiceImplIntegrationTest.java
+++ b/src/test/java/com/marafone/marafone/game/active/ActiveGameServiceImplIntegrationTest.java
@@ -56,23 +56,23 @@ class ActiveGameServiceImplIntegrationTest {
 
         //JOIN GAME - should fail
         User ownerTeamMate = DummyData.getUserB();
-        JoinGameRequest joinRedWrongCode = new JoinGameRequest(Team.RED, "123");
+        JoinGameRequest joinWrongCode = new JoinGameRequest("123");
 
-        JoinGameResult joined = activeGameService.joinGame(gameId, joinRedWrongCode, ownerTeamMate);
+        JoinGameResult joined = activeGameService.joinGame(gameId, joinWrongCode, ownerTeamMate);
 
         assertEquals(INCORRECT_PASSWORD, joined);
 
         //JOIN GAME - should join
-        JoinGameRequest joinRedGoodCode = new JoinGameRequest(Team.RED, "ABC");
+        JoinGameRequest joinGoodCode = new JoinGameRequest("ABC");
 
-        joined = activeGameService.joinGame(gameId, joinRedGoodCode, ownerTeamMate);
+        joined = activeGameService.joinGame(gameId, joinGoodCode, ownerTeamMate);
 
         assertEquals(SUCCESS, joined);
 
-        //JOIN ENEMY TEAM
+        //JOIN GAME - ENEMIES
         User firstEnemy = DummyData.getUserC();
         User secondEnemy = DummyData.getUserD();
-        JoinGameRequest joinBlueTeam = new JoinGameRequest(Team.BLUE, "ABC");
+        JoinGameRequest joinBlueTeam = new JoinGameRequest("ABC"); // when red team is full, users are joining blue one
         activeGameService.joinGame(gameId, joinBlueTeam, firstEnemy);
         activeGameService.joinGame(gameId, joinBlueTeam, secondEnemy);
 

--- a/src/test/java/com/marafone/marafone/game/active/ActiveGameServiceImplIntegrationWithMocksTest.java
+++ b/src/test/java/com/marafone/marafone/game/active/ActiveGameServiceImplIntegrationWithMocksTest.java
@@ -65,7 +65,7 @@ class ActiveGameServiceImplIntegrationWithMocksTest {
 
         //JOIN AS TEAMMATE
         User ownerTeamMate = DummyData.getUserB();
-        JoinGameRequest joinRedGoodCode = new JoinGameRequest(Team.RED, "ABC");
+        JoinGameRequest joinRedGoodCode = new JoinGameRequest("ABC"); // when there is space in team, red team join is automatically performed
 
         JoinGameResult joined = activeGameService.joinGame(gameId, joinRedGoodCode, ownerTeamMate);
 
@@ -74,7 +74,7 @@ class ActiveGameServiceImplIntegrationWithMocksTest {
         //JOIN ENEMY TEAM
         User firstEnemy = DummyData.getUserC();
         User secondEnemy = DummyData.getUserD();
-        JoinGameRequest joinBlueTeam = new JoinGameRequest(Team.BLUE, "ABC");
+        JoinGameRequest joinBlueTeam = new JoinGameRequest("ABC");
         activeGameService.joinGame(gameId, joinBlueTeam, firstEnemy);
         activeGameService.joinGame(gameId, joinBlueTeam, secondEnemy);
 
@@ -324,7 +324,7 @@ class ActiveGameServiceImplIntegrationWithMocksTest {
 
         //JOIN AS TEAMMATE
         User ownerTeamMate = DummyData.getUserB();
-        JoinGameRequest joinRedGoodCode = new JoinGameRequest(Team.RED, "ABC");
+        JoinGameRequest joinRedGoodCode = new JoinGameRequest("ABC");
 
         JoinGameResult joined = activeGameService.joinGame(gameId, joinRedGoodCode, ownerTeamMate);
 
@@ -333,7 +333,7 @@ class ActiveGameServiceImplIntegrationWithMocksTest {
         //JOIN ENEMY TEAM
         User firstEnemy = DummyData.getUserC();
         User secondEnemy = DummyData.getUserD();
-        JoinGameRequest joinBlueTeam = new JoinGameRequest(Team.BLUE, "ABC");
+        JoinGameRequest joinBlueTeam = new JoinGameRequest("ABC");
         activeGameService.joinGame(gameId, joinBlueTeam, firstEnemy);
         activeGameService.joinGame(gameId, joinBlueTeam, secondEnemy);
 

--- a/src/test/java/com/marafone/marafone/game/active/ActiveGameServiceImplIntegrationWithSeedTests.java
+++ b/src/test/java/com/marafone/marafone/game/active/ActiveGameServiceImplIntegrationWithSeedTests.java
@@ -70,7 +70,7 @@ class ActiveGameServiceImplIntegrationWithSeedTests {
 
         //JOIN AS TEAMMATE
         User ownerTeamMate = DummyData.getUserB();
-        JoinGameRequest joinRedGoodCode = new JoinGameRequest(Team.RED, "ABC");
+        JoinGameRequest joinRedGoodCode = new JoinGameRequest("ABC");
 
         JoinGameResult joined = activeGameService.joinGame(gameId, joinRedGoodCode, ownerTeamMate);
 
@@ -79,7 +79,7 @@ class ActiveGameServiceImplIntegrationWithSeedTests {
         //JOIN ENEMY TEAM
         User firstEnemy = DummyData.getUserC();
         User secondEnemy = DummyData.getUserD();
-        JoinGameRequest joinBlueTeam = new JoinGameRequest(Team.BLUE, "ABC");
+        JoinGameRequest joinBlueTeam = new JoinGameRequest("ABC");
         activeGameService.joinGame(gameId, joinBlueTeam, firstEnemy);
         activeGameService.joinGame(gameId, joinBlueTeam, secondEnemy);
 

--- a/src/test/java/com/marafone/marafone/game/active/ActiveGameServiceImplTest.java
+++ b/src/test/java/com/marafone/marafone/game/active/ActiveGameServiceImplTest.java
@@ -70,7 +70,7 @@ class ActiveGameServiceImplTest {
         Mockito.when(activeGameRepository.findById(any())).thenReturn(Optional.of(DummyData.getGameInLobby()));
 
         //when
-        JoinGameResult joined = activeGameServiceImpl.joinGame(1L, new JoinGameRequest(Team.RED, null), DummyData.getUserB());
+        JoinGameResult joined = activeGameServiceImpl.joinGame(1L, new JoinGameRequest(null), DummyData.getUserB());
 
         //then
         assertSame(JoinGameResult.SUCCESS, joined);
@@ -87,7 +87,7 @@ class ActiveGameServiceImplTest {
         Mockito.when(activeGameRepository.findById(any())).thenReturn(Optional.of(sampleGame));
 
         //when
-        JoinGameResult joined = activeGameServiceImpl.joinGame(1L, new JoinGameRequest(Team.RED, null), DummyData.getUserC());
+        JoinGameResult joined = activeGameServiceImpl.joinGame(1L, new JoinGameRequest(null), DummyData.getUserC());
 
         //then
         assertEquals(TEAMS_FULL, joined);
@@ -99,7 +99,7 @@ class ActiveGameServiceImplTest {
         Mockito.when(activeGameRepository.findById(any())).thenReturn(Optional.empty());
 
         //when
-        JoinGameResult joined = activeGameServiceImpl.joinGame(1L, new JoinGameRequest(Team.RED, null), DummyData.getUserA());
+        JoinGameResult joined = activeGameServiceImpl.joinGame(1L, new JoinGameRequest(null), DummyData.getUserA());
 
         //then
         assertEquals(GAME_NOT_FOUND, joined);
@@ -113,7 +113,7 @@ class ActiveGameServiceImplTest {
         Mockito.when(activeGameRepository.findById(any())).thenReturn(Optional.of(sampleGame));
 
         //when
-        JoinGameResult joined = activeGameServiceImpl.joinGame(1L, new JoinGameRequest(Team.RED, "ABC"), DummyData.getUserB());
+        JoinGameResult joined = activeGameServiceImpl.joinGame(1L, new JoinGameRequest("ABC"), DummyData.getUserB());
 
         //then
         assertEquals(INCORRECT_PASSWORD, joined);
@@ -125,8 +125,8 @@ class ActiveGameServiceImplTest {
         Mockito.when(activeGameRepository.findById(any())).thenReturn(Optional.of(DummyData.getGameInLobby()));
 
         //when
-        JoinGameResult joined = activeGameServiceImpl.joinGame(1L, new JoinGameRequest(Team.RED, null), DummyData.getUserB());
-        JoinGameResult joinedAgain = activeGameServiceImpl.joinGame(1L, new JoinGameRequest(Team.RED, null), DummyData.getUserB());
+        JoinGameResult joined = activeGameServiceImpl.joinGame(1L, new JoinGameRequest(null), DummyData.getUserB());
+        JoinGameResult joinedAgain = activeGameServiceImpl.joinGame(1L, new JoinGameRequest(null), DummyData.getUserB());
 
         //then
         assertEquals(SUCCESS, joined);
@@ -423,7 +423,7 @@ class ActiveGameServiceImplTest {
         Mockito.when(activeGameRepository.findById(any())).thenReturn(Optional.of(sampleGame));
 
         // when
-        JoinGameResult result = activeGameServiceImpl.joinGame(1L, new JoinGameRequest(Team.RED, null), DummyData.getUserA());
+        JoinGameResult result = activeGameServiceImpl.joinGame(1L, new JoinGameRequest(null), DummyData.getUserA());
 
         // then
         assertEquals(GAME_ALREADY_STARTED, result);


### PR DESCRIPTION
- Added isPrivate field to GameDTO to allow the frontend to distinguish between private and public games.
- Updated JoinGameRequest to remove the team selection option, as the backend logic automatically assigns players to a team with available space.
- Modified the repository method to return both public and private games. This change allows users to see private games in the lobby, which can be helpful if they prefer browsing over entering a game code directly.